### PR TITLE
temp: simplify homepage, redirect nav to external properties

### DIFF
--- a/src/components/CallToAction.astro
+++ b/src/components/CallToAction.astro
@@ -12,9 +12,9 @@
       <a href="https://discord.gg/superbenefit" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
         Get Involved
       </a>
-      <a href="/about" class="btn btn-ghost">
+      <!-- <a href="/about" class="btn btn-ghost">
         Learn More
-      </a>
+      </a> -->
     </div>
   </div>
 </section>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -6,21 +6,25 @@ interface Props {
 const { currentPath } = Astro.props;
 
 const links = [
-  { href: '/', label: 'Home' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
+  { href: 'https://knowledge.superbenefit.dev', label: 'Knowledge' },
+  { href: 'https://governance.superbenefit.dev', label: 'Governance' },
 ];
 ---
 
 <nav class="site-nav" aria-label="Main navigation">
   <ul>
     {links.map(({ href, label }) => {
-      const isActive = href === '/'
+      const isExternal = href.startsWith('http');
+      const isActive = !isExternal && (href === '/'
         ? currentPath === '/'
-        : currentPath.startsWith(href);
+        : currentPath.startsWith(href));
       return (
         <li>
-          <a href={href} class:list={['nav-link', { active: isActive }]}>
+          <a
+            href={href}
+            class:list={['nav-link', { active: isActive }]}
+            {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+          >
             {label}
           </a>
         </li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,22 +5,22 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Hero from '../components/Hero.astro';
 import SectionDivider from '../components/SectionDivider.astro';
 import MissionStatement from '../components/MissionStatement.astro';
-import CardsStage from '../components/CardsStage.astro';
-import StorySection from '../components/StorySection.astro';
+// import CardsStage from '../components/CardsStage.astro';
+// import StorySection from '../components/StorySection.astro';
 import CallToAction from '../components/CallToAction.astro';
-import { getCollection } from 'astro:content';
-import salonBg from '../assets/images/salon-bg.webp';
-import playbookBg from '../assets/images/playbook-bg.webp';
-import vaultBg from '../assets/images/vault-bg.webp';
+// import { getCollection } from 'astro:content';
+// import salonBg from '../assets/images/salon-bg.webp';
+// import playbookBg from '../assets/images/playbook-bg.webp';
+// import vaultBg from '../assets/images/vault-bg.webp';
 
-const allPosts = await getCollection('blog', ({ data }) => !data.draft);
-const recentPosts = allPosts
-  .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
-  .slice(0, 3);
+// const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+// const recentPosts = allPosts
+//   .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
+//   .slice(0, 3);
 
-const allProjects = await getCollection('projects', ({ data }) => !data.draft);
-const projects = allProjects
-  .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+// const allProjects = await getCollection('projects', ({ data }) => !data.draft);
+// const projects = allProjects
+//   .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
 ---
 
 <BaseLayout
@@ -31,8 +31,8 @@ const projects = allProjects
   <SectionDivider from="black" to="cream" />
   <MissionStatement />
 
-  <CardsStage>
-    {/* <StorySection
+  <!-- <CardsStage>
+    <StorySection
       theme="green"
       bgImage={salonBg}
       label="Shared Space"
@@ -46,7 +46,7 @@ const projects = allProjects
         View Events
       </a>
       <a href="/gatherings" class="story-btn story-btn--ghost">Browse Gatherings</a>
-    </StorySection> */}
+    </StorySection>
 
     <StorySection
       theme="orange"
@@ -84,7 +84,7 @@ const projects = allProjects
       </a>
       <a href="/about" class="story-btn story-btn--ghost">Learn More</a>
     </StorySection>
-  </CardsStage>
+  </CardsStage> -->
 
   <CallToAction />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Comment out `CardsStage`/`StorySection` components (were linking to non-existent `/events`, `/gatherings`, `/projects` pages)
- Update nav to point to external Knowledge and Governance properties
- Remove "Learn More" CTA button (no internal About page yet)

## Context
Temporary simplification while homepage content is being developed.