### PR TITLE
fix(csp): add static.cloudflareinsights.com to script-src for Web Analytics beacon

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://knowledge.superbenefit.org https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://knowledge.superbenefit.org https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
 # Draft-gated pages — keep them out of search indexes until shipped.
 # Meta noindex is also set in BaseLayout when showDraftPlaceholder is true.


### PR DESCRIPTION
## Summary

Cloudflare Web Analytics auto-injects a beacon script from `https://static.cloudflareinsights.com/beacon.min.js` at the edge. Our CSP `script-src` directive did not include this domain, so the script was blocked from loading and analytics data was never reported.

## Change

Added `https://static.cloudflareinsights.com` to the `script-src` CSP directive in `public/_headers`.

`connect-src 'self'` already covers the beacon's POST to `/cdn-cgi/rum` on the same domain (this is a proxied Workers site), so no change needed there.

## Console Warning Audit

Also audited the remaining ~40 browser console warnings. All originate from Cloudflare's Turnstile challenge platform iframe (third-party, unreachable from our code):
- **32×** Feature Policy: unsupported feature names — Firefox Permissions-Policy implementation gaps for standardized features
- **8×** Partitioned cookies, deprecated APIs, font load, WebGL — Turnstile internals

Verified against official Turnstile CSP docs — our configuration is complete and correct.

## Refs

- [Web Analytics CSP FAQ](https://developers.cloudflare.com/web-analytics/faq/#what-do-i-need-to-add-to-my-content-security-policy-csp)
- [Turnstile CSP Reference](https://developers.cloudflare.com/turnstile/reference/content-security-policy/)