### PR TITLE
fix(ui): repair mobile nav, footer badge, and visual seams

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,7 +29,7 @@ const year = new Date().getFullYear();
 
     <div class="footer-right">
       <a href="https://ethereum.org" target="_blank" rel="noopener noreferrer" class="footer-badge">
-        <Image src={builtOnEth} alt="Built on Ethereum" width={160} height={48} loading="lazy" />
+        <Image src={builtOnEth} alt="Built on Ethereum" loading="lazy" />
       </a>
     </div>
   </div>
@@ -133,7 +133,7 @@ const year = new Date().getFullYear();
   }
 
   .footer-badge {
-    display: block;
+    display: inline-block;
     opacity: 0.7;
     transition: opacity var(--transition-fast);
   }
@@ -163,15 +163,46 @@ const year = new Date().getFullYear();
     text-align: center;
   }
 
-  /* Mobile: stack to single column */
-  @media (max-width: 640px) {
+  /* Mobile: stack to single column and enlarge brand elements */
+  @media (max-width: 768px) {
     .footer-inner {
       grid-template-columns: 1fr;
-      gap: var(--space-lg);
+      gap: 2.5rem;
+      text-align: center;
+    }
+
+    .footer-brand {
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .footer-icon {
+      width: 48px;
+      height: 48px;
+    }
+
+    .footer-name {
+      font-size: 1.25rem;
+    }
+
+    .footer-social {
+      margin-inline-start: 0;
+      gap: var(--space-sm);
+    }
+
+    .footer-social a svg {
+      width: 24px;
+      height: 24px;
     }
 
     .footer-right {
-      align-items: flex-start;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .footer-badge img {
+      height: 52px;
     }
   }
 </style>

--- a/src/components/FooterFade.astro
+++ b/src/components/FooterFade.astro
@@ -34,6 +34,8 @@
     background: linear-gradient(to bottom, var(--color-charcoal) 0%, var(--color-black) 100%);
     line-height: 0;
     overflow: hidden;
+    transform: scaleY(1.02);
+    transform-origin: bottom;
   }
 
   .fade-wave {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,8 +2,14 @@
 import { Image } from 'astro:assets';
 import icon from '../assets/sb-icon.jpg';
 import Nav from './Nav.astro';
+import { mainNavLinks, contactNavLink } from '../data/nav';
+import { isNavLinkActive } from '../utils/nav';
 
 const currentPath = Astro.url.pathname;
+
+const links = mainNavLinks;
+const contact = contactNavLink;
+const contactActive = isNavLinkActive(currentPath, contact.href);
 ---
 
 <header class="site-header" transition:persist>
@@ -13,11 +19,44 @@ const currentPath = Astro.url.pathname;
       <span class="logo-text">SuperBenefit</span>
     </a>
     <Nav currentPath={currentPath} />
-    <button class="mobile-toggle" aria-label="Toggle menu" aria-expanded="false">
+    <button class="mobile-toggle" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-nav">
       <span class="hamburger"></span>
     </button>
   </div>
   <div class="header-rainbow"></div>
+
+  <dialog class="mobile-nav-dialog" id="mobile-nav" aria-label="Mobile navigation">
+    <form method="dialog" class="mobile-nav-close-form">
+      <button class="mobile-nav-close" aria-label="Close menu" type="submit">×</button>
+    </form>
+    <nav class="mobile-nav" aria-label="Mobile navigation">
+      <ul class="mobile-nav-links">
+        {links.map(({ href, label }) => {
+          const active = isNavLinkActive(currentPath, href);
+          return (
+            <li>
+              <a
+                href={href}
+                class:list={['mobile-nav-link', { active }]}
+                aria-current={active ? 'page' : undefined}
+              >
+                {label}
+              </a>
+            </li>
+          );
+        })}
+        <li>
+          <a
+            href={contact.href}
+            class:list={['mobile-nav-link mobile-nav-contact', { active: contactActive }]}
+            aria-current={contactActive ? 'page' : undefined}
+          >
+            {contact.label}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </dialog>
 </header>
 
 <script>
@@ -25,8 +64,8 @@ const currentPath = Astro.url.pathname;
 
   document.addEventListener('astro:page-load', () => {
     const toggle = document.querySelector<HTMLButtonElement>('.mobile-toggle');
-    const nav = document.querySelector<HTMLElement>('.site-nav');
-    if (!toggle || !nav) return;
+    const dialog = document.querySelector<HTMLDialogElement>('#mobile-nav');
+    if (!toggle || !dialog) return;
 
     // The <header> is transition:persist-ed across view transitions, so its
     // DOM nodes (and this handler) re-fire on every astro:page-load.
@@ -44,78 +83,43 @@ const currentPath = Astro.url.pathname;
       });
     }
 
-    const isOpen = (): boolean =>
-      toggle.getAttribute('aria-expanded') === 'true';
+    const isOpen = (): boolean => dialog.open;
+
+    const openMenu = (): void => {
+      dialog.showModal();
+      toggle.setAttribute('aria-expanded', 'true');
+      document.body.classList.add('nav-open');
+    };
+
+    const closeMenu = (): void => {
+      dialog.close();
+    };
+
+    // The dialog emits a close event when dismissed via the form button,
+    // backdrop click, or Escape key — keep ARIA and body lock in sync.
+    dialog.addEventListener('close', () => {
+      toggle.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('nav-open');
+    });
 
     // Close mobile menu when a homepage section anchor link is clicked.
     // Anchor links (hrefs containing "/#") scroll to sections on the
     // current page; the menu should close before the scroll happens.
-    nav.addEventListener('click', (e) => {
+    dialog.addEventListener('click', (e) => {
       const link = (e.target as Element).closest('a[href*="/#"]');
       if (link && isOpen()) {
         closeMenu();
       }
     });
 
-    const setBackgroundInert = (inert: boolean): void => {
-      // <main> and <footer> are not persisted, so querySelector each call
-      // (they're fresh nodes after every view transition).
-      const main = document.querySelector<HTMLElement>('main');
-      const footer = document.querySelector<HTMLElement>('.site-footer');
-      if (inert) {
-        main?.setAttribute('inert', '');
-        footer?.setAttribute('inert', '');
-      } else {
-        main?.removeAttribute('inert');
-        footer?.removeAttribute('inert');
-      }
-    };
-
-    const openMenu = (): void => {
-      toggle.setAttribute('aria-expanded', 'true');
-      nav.classList.add('is-open');
-      document.body.classList.add('nav-open');
-      setBackgroundInert(true);
-      const firstFocusable = nav.querySelector<HTMLElement>('a, button');
-      firstFocusable?.focus();
-    };
-
-    const closeMenu = (returnFocus = true): void => {
-      toggle.setAttribute('aria-expanded', 'false');
-      nav.classList.remove('is-open');
-      document.body.classList.remove('nav-open');
-      setBackgroundInert(false);
-      if (returnFocus) toggle.focus();
-    };
-
     toggle.addEventListener('click', () => {
       isOpen() ? closeMenu() : openMenu();
-    });
-
-    // Escape closes the menu from anywhere on the page.
-    document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && isOpen()) {
-        event.preventDefault();
-        closeMenu();
-      }
     });
 
     // Auto-close before view-transition navigation so the menu doesn't
     // persist open on the next page (the header itself is persisted).
     document.addEventListener('astro:before-preparation', () => {
-      if (isOpen()) closeMenu(false);
-    });
-
-    // After a view-transition swap, <main>/<footer> are fresh nodes;
-    // re-apply inert if the menu somehow stayed open across the swap.
-    document.addEventListener('astro:after-swap', () => {
-      if (isOpen()) setBackgroundInert(true);
-    });
-
-    // If the user resizes from mobile to desktop while the menu is open,
-    // the overlay becomes hidden by media query but state would persist.
-    window.addEventListener('resize', () => {
-      if (window.innerWidth > 768 && isOpen()) closeMenu(false);
+      if (isOpen()) closeMenu();
     });
   });
 </script>
@@ -215,6 +219,99 @@ const currentPath = Astro.url.pathname;
   .mobile-toggle[aria-expanded="true"] .hamburger::after {
     top: 0;
     transform: rotate(-45deg);
+  }
+
+  .mobile-nav-dialog {
+    margin: 0;
+    padding: 0;
+    border: none;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    background: var(--color-black);
+    color: var(--color-cream);
+    overflow: hidden;
+  }
+
+  .mobile-nav-dialog[open] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mobile-nav-dialog::backdrop {
+    background: rgb(var(--color-black-rgb) / 0.8);
+    backdrop-filter: blur(10px);
+  }
+
+  .mobile-nav-close-form {
+    position: absolute;
+    top: var(--space-lg);
+    right: var(--space-lg);
+    z-index: 1;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mobile-nav-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    font-size: var(--text-2xl);
+    line-height: 1;
+    color: var(--color-cream);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+
+  .mobile-nav-close:focus-visible {
+    outline: 2px solid var(--color-orange);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .mobile-nav {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-block-start: var(--space-2xl);
+    padding-block-end: var(--space-2xl);
+    padding-inline: var(--space-lg);
+  }
+
+  .mobile-nav-links {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-md);
+    list-style: none;
+  }
+
+  .mobile-nav-link {
+    color: var(--color-cream);
+    font-size: var(--text-xl);
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .mobile-nav-link:hover,
+  .mobile-nav-link.active {
+    color: var(--color-orange);
+  }
+
+  .mobile-nav-contact {
+    color: var(--color-orange);
+  }
+
+  .mobile-nav-contact:hover,
+  .mobile-nav-contact.active {
+    color: var(--color-cream);
   }
 
   @media (max-width: 768px) {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,5 +1,7 @@
 ---
 import { isNavLinkActive } from '../utils/nav';
+import { mainNavLinks, contactNavLink } from '../data/nav';
+import type { NavLink } from '../data/nav';
 
 interface Props {
   currentPath: string;
@@ -7,15 +9,9 @@ interface Props {
 
 const { currentPath } = Astro.props;
 
-const links = [
-  { href: '/#about', label: 'About' },
-  { href: '/#support', label: 'Support' },
-  { href: '/#services', label: 'Services' },
-];
-
-const ctaHref = '/contact';
-const ctaLabel = 'Contact';
-const ctaActive = isNavLinkActive(currentPath, ctaHref);
+const links: NavLink[] = mainNavLinks;
+const cta = contactNavLink;
+const ctaActive = isNavLinkActive(currentPath, cta.href);
 ---
 
 <nav class="site-nav" aria-label="Main navigation">
@@ -36,11 +32,11 @@ const ctaActive = isNavLinkActive(currentPath, ctaHref);
     })}
   </ul>
   <a
-    href={ctaHref}
+    href={cta.href}
     class:list={['nav-cta', { active: ctaActive }]}
     aria-current={ctaActive ? 'page' : undefined}
   >
-    {ctaLabel}
+    {cta.label}
   </a>
 </nav>
 
@@ -95,7 +91,6 @@ const ctaActive = isNavLinkActive(currentPath, ctaHref);
     color: var(--color-orange);
   }
 
-  /* Contact CTA — pushed to the right edge of the nav with margin-inline-start: auto */
   .nav-cta {
     margin-inline-start: auto;
     display: inline-flex;
@@ -133,45 +128,7 @@ const ctaActive = isNavLinkActive(currentPath, ctaHref);
 
   @media (max-width: 768px) {
     .site-nav {
-      position: fixed;
-      top: var(--header-height);
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgb(var(--color-black-rgb) / 0.97);
-      backdrop-filter: blur(16px);
-      flex-direction: column;
-      justify-content: center;
-      align-items: stretch;
-      gap: 0;
-      padding: var(--space-xl) var(--space-lg);
-      opacity: 0;
-      visibility: hidden;
-      transition:
-        opacity var(--transition-medium),
-        visibility var(--transition-medium);
-    }
-
-    .site-nav.is-open {
-      opacity: 1;
-      visibility: visible;
-    }
-
-    .site-nav-links {
-      flex-direction: column;
-      align-items: center;
-      gap: var(--space-xl);
-    }
-
-    .nav-link {
-      font-size: var(--text-xl);
-    }
-
-    .nav-cta {
-      margin: var(--space-2xl) auto 0;
-      padding: var(--space-md) var(--space-xl);
-      font-size: var(--text-base);
-      justify-content: center;
+      display: none;
     }
   }
 </style>

--- a/src/components/SectionDivider.astro
+++ b/src/components/SectionDivider.astro
@@ -71,6 +71,8 @@ const svgAngle = gradient?.angle != null
     height: 60px;
     margin-top: -60px;
     line-height: 0;
+    transform: scaleY(1.02);
+    transform-origin: bottom;
   }
 
   .section-divider svg {
@@ -83,6 +85,8 @@ const svgAngle = gradient?.angle != null
     .section-divider {
       height: 80px;
       margin-top: -80px;
+      transform: scaleY(1.02);
+      transform-origin: bottom;
     }
 
     .section-divider svg {

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -1,0 +1,12 @@
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+export const mainNavLinks: NavLink[] = [
+  { href: '/#about', label: 'About' },
+  { href: '/#support', label: 'Support' },
+  { href: '/#services', label: 'Services' },
+];
+
+export const contactNavLink: NavLink = { href: '/contact', label: 'Contact' };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -121,11 +121,9 @@ const websiteSchema = isHomepage
           }
         }
 
-        // Links inside .site-nav (nav links + mobile contact CTA)
-        document.querySelectorAll<HTMLAnchorElement>('.site-nav a').forEach(setActive);
-
-        // Desktop contact CTA (outside .site-nav, inside .header-inner)
-        document.querySelectorAll<HTMLAnchorElement>('.header-cta').forEach(setActive);
+        // Links inside .site-nav (desktop nav links + CTA) and .mobile-nav
+        // (mobile menu links + Contact).
+        document.querySelectorAll<HTMLAnchorElement>('.site-nav a, .mobile-nav a').forEach(setActive);
       }
       document.addEventListener('astro:page-load', updateNavActive);
 


### PR DESCRIPTION
## Summary

- Fixes the mobile header disappearing due to a forced `display:block` on the closed `<dialog>`.
- Refactors mobile navigation so the toggle and its dialog live together in `Header.astro`.
- Extracts shared nav links into `src/data/nav.ts`.
- Styles mobile Contact as plain orange text instead of a button.
- Fixes Ethereum badge letterboxing by removing hardcoded image dimensions.
- Adjusts mobile footer brand/icon/social sizing and badge spacing.
- Adds `scaleY(1.02)` to `FooterFade` and `SectionDivider` to hide visual seams.

## Validation

- `npm run check` passes (0 errors, 0 warnings, 0 hints)
- `npm run build` completes successfully